### PR TITLE
feat: support additional scrubbing configuration and callbacks

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -24,6 +24,8 @@ if Code.ensure_loaded?(Plug) do
 
     @doc false
     def build_metadata(conn, latency, client_version_header) do
+      scrub_map = scrub_map(scrub_overrides())
+
       client_metadata(conn, client_version_header) ++
         phoenix_metadata(conn) ++
         [
@@ -34,9 +36,9 @@ if Code.ensure_loaded?(Plug) do
               status_code: conn.status,
               method: conn.method,
               referer: LoggerJSON.PlugUtils.get_header(conn, "referer"),
-              request_headers: recursive_scrub(conn.req_headers),
               request_id: Keyword.get(Logger.metadata(), :request_id),
-              request_params: recursive_scrub(conn.params),
+              request_headers: recursive_scrub(conn.req_headers, scrub_map),
+              request_params: recursive_scrub(conn.params, scrub_map),
               useragent: LoggerJSON.PlugUtils.get_header(conn, "user-agent"),
               url_details:
                 json_map(
@@ -51,13 +53,8 @@ if Code.ensure_loaded?(Plug) do
         ]
     end
 
-    defp native_to_nanoseconds(nil) do
-      nil
-    end
-
-    defp native_to_nanoseconds(native) do
-      System.convert_time_unit(native, :native, :nanosecond)
-    end
+    defp native_to_nanoseconds(nil), do: nil
+    defp native_to_nanoseconds(native), do: System.convert_time_unit(native, :native, :nanosecond)
 
     defp request_url(%{request_path: "/"} = conn), do: "#{conn.scheme}://#{conn.host}/"
     defp request_url(conn), do: "#{conn.scheme}://#{Path.join(conn.host, conn.request_path)}"
@@ -74,9 +71,7 @@ if Code.ensure_loaded?(Plug) do
       [phoenix: json_map(controller: controller, action: action, route: phoenix_route(conn))]
     end
 
-    defp phoenix_metadata(_conn) do
-      []
-    end
+    defp phoenix_metadata(_conn), do: []
 
     if Code.ensure_loaded?(Phoenix.Router) do
       defp phoenix_route(%{private: %{phoenix_router: router}, method: method, request_path: path, host: host}) do
@@ -89,31 +84,53 @@ if Code.ensure_loaded?(Plug) do
 
     defp phoenix_route(_conn), do: nil
 
-    defp recursive_scrub(%{__struct__: Plug.Conn.Unfetched}),
-      do: "%Plug.Conn.Unfetched{}"
+    defp scrub_overrides, do: Application.get_env(:logger_json, :scrub_overrides, %{})
+    defp default_scrub_value, do: Application.get_env(:logger_json, :scrubbed_value, @scrubbed_value)
 
-    defp recursive_scrub([head | _tail] = data) when is_tuple(head),
-      do: data |> Enum.map(&recursive_scrub/1) |> Map.new()
-
-    defp recursive_scrub(data) when is_list(data) and length(data) > 100,
-      do: "List of #{length(data)} items"
-
-    defp recursive_scrub(data) when is_list(data),
-      do: Enum.map(data, &recursive_scrub/1)
-
-    defp recursive_scrub(data) when is_struct(data),
-      do: data |> Map.from_struct() |> recursive_scrub()
-
-    defp recursive_scrub({k, _v}) when k in @scrubbed_keys,
-      do: {k, @scrubbed_value}
-
-    defp recursive_scrub(data) when is_map(data) do
-      Map.new(data, fn
-        {k, _v} when k in @scrubbed_keys -> {k, @scrubbed_value}
-        {k, v} -> {k, recursive_scrub(v)}
+    defp scrub_map(overrides) do
+      Enum.reduce(@scrubbed_keys, overrides, fn key, acc ->
+        Map.put_new(acc, key, default_scrub_value())
       end)
     end
 
-    defp recursive_scrub(data), do: data
+    defp scrubbed_value(key, scrub_map) do
+      if Map.has_key?(scrub_map, key) do
+        Map.get(scrub_map, key, default_scrub_value())
+      else
+        nil
+      end
+    end
+
+    defp recursive_scrub(%{__struct__: Plug.Conn.Unfetched}, _scrub_map), do: "%Plug.Conn.Unfetched{}"
+
+    defp recursive_scrub([head | _tail] = data, scrub_map) when is_tuple(head),
+      do: data |> Enum.map(&recursive_scrub(&1, scrub_map)) |> Map.new()
+
+    defp recursive_scrub(data, scrub_map) when is_list(data),
+      do: Enum.map(data, &recursive_scrub(&1, scrub_map))
+
+    defp recursive_scrub(data, scrub_map) when is_map(data) do
+      Map.new(data, fn {k, v} ->
+        scrub_value = scrubbed_value(k, scrub_map)
+
+        if scrub_value do
+          {k, scrub_value}
+        else
+          {k, recursive_scrub(v, scrub_map)}
+        end
+      end)
+    end
+
+    defp recursive_scrub({k, v}, scrub_map) do
+      scrub_value = scrubbed_value(k, scrub_map)
+
+      if is_function(scrub_value) do
+        {k, scrub_value.(v)}
+      else
+        {k, scrub_value || recursive_scrub(v, scrub_map)}
+      end
+    end
+
+    defp recursive_scrub(data, _), do: data
   end
 end

--- a/test/unit/logger_json/plug/datadog_logger_test.exs
+++ b/test/unit/logger_json/plug/datadog_logger_test.exs
@@ -180,6 +180,12 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
   end
 
   describe "configuration: :scrub_overrides" do
+    defmodule ScrubHelpers do
+      def reverse(value) do
+        String.reverse(value)
+      end
+    end
+
     setup do
       :ok =
         Logger.configure_backend(
@@ -195,7 +201,7 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
 
       override_application_env(:logger_json, :scrub_overrides, %{
         "some-unicorn-key-super-special-lul" => "$$$$",
-        "use-a-callback" => fn value -> String.reverse(value) end
+        "use-a-callback" => {ScrubHelpers, :reverse, []}
       })
     end
 

--- a/test/unit/logger_json/plug/datadog_logger_test.exs
+++ b/test/unit/logger_json/plug/datadog_logger_test.exs
@@ -1,4 +1,4 @@
-# The use Plug.Builder in another nested module is causing this check to fail.
+# The use of Plug.Builder in another nested module is causing this check to fail.
 # credo:disable-for-this-file Credo.Check.Consistency.MultiAliasImportRequireUse
 defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
   use Logger.Case, async: false
@@ -21,119 +21,213 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
     end
   end
 
-  setup do
-    :ok =
-      Logger.configure_backend(
-        LoggerJSON,
-        device: :standard_error,
-        level: nil,
-        metadata: :all,
-        json_encoder: Jason,
-        on_init: :disabled,
-        formatter: LoggerJSON.Formatters.GoogleCloudLogger,
-        formatter_state: %{}
-      )
-  end
+  describe "default behavior" do
+    setup do
+      :ok =
+        Logger.configure_backend(
+          LoggerJSON,
+          device: :standard_error,
+          level: nil,
+          metadata: :all,
+          json_encoder: Jason,
+          on_init: :disabled,
+          formatter: LoggerJSON.Formatters.DatadogLogger,
+          formatter_state: %{}
+        )
+    end
 
-  test "logs request headers" do
-    conn =
-      :post
-      |> conn("/hello/world", [])
-      |> put_req_header("user-agent", "chrome")
-      |> put_req_header("referer", "http://google.com")
-      |> put_req_header("x-forwarded-for", "127.0.0.10")
-      |> put_req_header("x-api-version", "2017-01-01")
+    test "logs request headers" do
+      conn =
+        :post
+        |> conn("/hello/world", [])
+        |> put_req_header("user-agent", "chrome")
+        |> put_req_header("referer", "http://google.com")
+        |> put_req_header("x-forwarded-for", "127.0.0.10")
+        |> put_req_header("x-api-version", "2017-01-01")
 
-    log =
-      capture_io(:standard_error, fn ->
-        MyPlug.call(conn, [])
-        Logger.flush()
-        Process.sleep(10)
-      end)
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
 
-    assert %{
-             "http" => %{
-               "request_headers" => %{
-                 "referer" => "http://google.com",
-                 "user-agent" => "chrome",
-                 "x-api-version" => "2017-01-01",
-                 "x-forwarded-for" => "127.0.0.10"
+      assert %{
+               "http" => %{
+                 "request_headers" => %{
+                   "referer" => "http://google.com",
+                   "user-agent" => "chrome",
+                   "x-api-version" => "2017-01-01",
+                   "x-forwarded-for" => "127.0.0.10"
+                 }
                }
-             }
-           } = Jason.decode!(log)
-  end
+             } = Jason.decode!(log)
+    end
 
-  test "scrubs sensitive request headers" do
-    conn =
-      :post
-      |> conn("/hello/world", [])
-      |> put_req_header("authorization", "Bearer TESTING")
-      |> put_req_header("cookie", "iwannacookie")
-      |> put_req_header("x-cloud-signature", "pleasedontleakmebro")
+    test "scrubs sensitive request headers" do
+      conn =
+        :post
+        |> conn("/hello/world", [])
+        |> put_req_header("authorization", "Bearer TESTING")
+        |> put_req_header("cookie", "iwannacookie")
+        |> put_req_header("x-cloud-signature", "pleasedontleakmebro")
 
-    log =
-      capture_io(:standard_error, fn ->
-        MyPlug.call(conn, [])
-        Logger.flush()
-        Process.sleep(10)
-      end)
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
 
-    assert %{
-             "http" => %{
-               "request_headers" => %{
-                 "authorization" => "*********",
-                 "cookie" => "*********",
-                 "x-cloud-signature" => "*********"
+      assert %{
+               "http" => %{
+                 "request_headers" => %{
+                   "authorization" => "*********",
+                   "cookie" => "*********",
+                   "x-cloud-signature" => "*********"
+                 }
                }
-             }
-           } = Jason.decode!(log)
-  end
+             } = Jason.decode!(log)
+    end
 
-  test "logs request body" do
-    conn =
-      :post
-      |> conn("/hello/world", Jason.encode!(%{hello: :world}))
-      |> put_req_header("content-type", "application/json")
+    test "logs request body" do
+      conn =
+        :post
+        |> conn("/hello/world", Jason.encode!(%{hello: :world}))
+        |> put_req_header("content-type", "application/json")
 
-    log =
-      capture_io(:standard_error, fn ->
-        MyPlug.call(conn, [])
-        Logger.flush()
-        Process.sleep(10)
-      end)
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
 
-    assert %{
-             "http" => %{
-               "request_params" => %{
-                 "hello" => "world"
+      assert %{
+               "http" => %{
+                 "request_params" => %{
+                   "hello" => "world"
+                 }
                }
-             }
-           } = Jason.decode!(log)
-  end
+             } = Jason.decode!(log)
+    end
 
-  test "scrubs nested request body keys" do
-    conn =
-      :post
-      |> conn("/hello/world", Jason.encode!(%{test: %{key: %{password: "sensitive"}}}))
-      |> put_req_header("content-type", "application/json")
+    test "scrubs nested request body keys" do
+      conn =
+        :post
+        |> conn("/hello/world", Jason.encode!(%{test: %{key: %{password: "sensitive"}}}))
+        |> put_req_header("content-type", "application/json")
 
-    log =
-      capture_io(:standard_error, fn ->
-        MyPlug.call(conn, [])
-        Logger.flush()
-        Process.sleep(10)
-      end)
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
 
-    assert %{
-             "http" => %{
-               "request_params" => %{
-                 "test" => %{
-                   "key" => %{
-                     "password" => "*********"
+      assert %{
+               "http" => %{
+                 "request_params" => %{
+                   "test" => %{
+                     "key" => %{
+                       "password" => "*********"
+                     }
                    }
                  }
                }
-             }
-           } = Jason.decode!(log)
+             } = Jason.decode!(log)
+    end
+  end
+
+  describe "specifying scrub_overrides configuration" do
+    setup do
+      :ok =
+        Logger.configure_backend(
+          LoggerJSON,
+          device: :standard_error,
+          level: nil,
+          metadata: :all,
+          json_encoder: Jason,
+          on_init: :disabled,
+          formatter: LoggerJSON.Formatters.DatadogLogger,
+          formatter_state: %{}
+        )
+
+      override_application_env(:logger_json, :scrub_overrides, %{
+        "some-unicorn-key-super-special-lul" => "$$$$",
+        "use-a-callback" => fn value -> String.reverse(value) end
+      })
+    end
+
+    test "scrubs with an individual value override and/or callback" do
+      callback_value = "you-should-not-see-me-either"
+
+      conn =
+        :post
+        |> conn("/hello/world", [])
+        |> put_req_header("some-unicorn-key-super-special-lul", "you-should-not-see-me")
+        |> put_req_header("use-a-callback", callback_value)
+        |> put_req_header("authorization", "Bearer VERY-LEAKABLE-API-KEY")
+
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
+
+      expected_callback_result = String.reverse(callback_value)
+
+      assert %{
+               "http" => %{
+                 "request_headers" => %{
+                   "authorization" => "*********",
+                   "some-unicorn-key-super-special-lul" => "$$$$",
+                   "use-a-callback" => ^expected_callback_result
+                 }
+               }
+             } = Jason.decode!(log)
+    end
+
+    test "merges the default scrub behavior in with the overrides" do
+      callback_value = "party-time"
+
+      conn =
+        :post
+        |> conn("/hello/world", [])
+        |> put_req_header("some-unicorn-key-super-special-lul", "you-should-not-see-me")
+        |> put_req_header("use-a-callback", "party-time")
+
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
+
+      expected_callback_result = String.reverse(callback_value)
+
+      assert %{
+               "http" => %{
+                 "request_headers" => %{
+                   "some-unicorn-key-super-special-lul" => "$$$$",
+                   "use-a-callback" => ^expected_callback_result
+                 }
+               }
+             } = Jason.decode!(log)
+    end
+  end
+
+  defp override_application_env(app, key, value) do
+    previous_value = Application.get_env(app, key)
+    Application.put_env(app, key, value)
+
+    on_exit(fn ->
+      if previous_value do
+        Application.put_env(app, key, previous_value)
+      else
+        Application.delete_env(app, key)
+      end
+    end)
   end
 end


### PR DESCRIPTION
- Allows for callbacks on scrub values
- Allows for overriding the defaults _(we'll probably never do this, but it's possible. e.g. `"authentication", fn v -> v end`)_
- Non-breaking change

The benefit here being that when we need to easily track back API key usage for cloud-enabled services, this lets that happen. The use case we have is specifically for returning the "public header" from an API key in logs (and api usage dashboards like readme).
