### PR TITLE
feat: default authorization header callback to support stord api keys

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -18,7 +18,8 @@ if Code.ensure_loaded?(Plug) do
       "passwd",
       "password",
       "secret",
-      "x-cloud-signature"
+      "x-cloud-signature",
+      "x-authorization"
     ]
     @scrubbed_value "*********"
 

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -98,13 +98,14 @@ if Code.ensure_loaded?(Plug) do
     end
 
     @doc """
-        Scrubs the private part of the authorization header while keeping the public part for additional observability possibilities.
+    Scrubs the private part of the authorization header while keeping the public part for additional observability possibilities.
 
-        ## Notes:
-        - Secret/App key headers are Base64 encoded and divisible by 3 and will never contain the padding (=) character.
-        - This is internally referred to as the `secret_key_header`. The public part of the key is retained in the output for name recognition and less ambiguity.
-        - The expected outcome would be something like "stord_sk_publickeyasdfasdf_*******", assuming "*******" is the scrub value.
-        - You can use DataDog's regex to extract the public key part and turn it into a standard attribute.
+    ## Notes:
+
+    - Secret/App key headers are Base64 encoded and divisible by 3 and will never contain the padding (=) character.
+    - This is internally referred to as the `secret_key_header`. The public part of the key is retained in the output for name recognition and less ambiguity.
+    - The expected outcome would be something like "stord_sk_publickeyasdfasdf_*******", assuming "*******" is the scrub value.
+    - You can use DataDog's regex to extract the public key part and turn it into a standard attribute.
     """
     def extract_public_key(value, scrub_value) do
       case Regex.named_captures(

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -101,11 +101,11 @@ if Code.ensure_loaded?(Plug) do
     Extracts the public part from the authorization header and returns it as the scrubbed value for additional observability.
 
     ## Notes:
-    - Secret key headers are Base64 encoded and divisible by 3 and will never contain the padding (=) character.
+    - Secret/App key headers are Base64 encoded and divisible by 3 and will never contain the padding (=) character.
     - This is internally referred to as the `secret_key_header`, but calling it a public_key for name recognition and to be less scary.
     """
     def extract_public_key(value, default_value) do
-      case Regex.named_captures(~r/Bearer stord_sk_(?<public_key>[A-Za-z0-9+\/]+)_.+/, value) do
+      case Regex.named_captures(~r/Bearer stord_(sk|ak)_(?<public_key>[A-Za-z0-9+\/]+)_.+/, value) do
         %{"public_key" => public_key} -> public_key
         _ -> default_value
       end

--- a/test/unit/logger_json/plug/datadog_logger_test.exs
+++ b/test/unit/logger_json/plug/datadog_logger_test.exs
@@ -91,12 +91,14 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
     end
 
     test "scrubs a cloud-service authorization header with secret key, extracts the secret_key_header and returns it as the scrub value" do
+      secret_key = "somesecretkeyvaluel0l"
       secret_key_header = "S9qb802LOup/zg3cd4m+CDsR"
+      key_type = "stord_sk"
 
       conn =
         :post
         |> conn("/hello/world", [])
-        |> put_req_header("authorization", "Bearer stord_sk_#{secret_key_header}_somesecretkeyvaluel0l")
+        |> put_req_header("authorization", "Bearer #{key_type}_#{secret_key_header}_#{secret_key}")
 
       log =
         capture_io(:standard_error, fn ->
@@ -105,22 +107,26 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
           Process.sleep(10)
         end)
 
+      expected_scrubbed_value = "#{key_type}_#{secret_key_header}_*********"
+
       assert %{
                "http" => %{
                  "request_headers" => %{
-                   "authorization" => ^secret_key_header
+                   "authorization" => ^expected_scrubbed_value
                  }
                }
              } = Jason.decode!(log)
     end
 
     test "scrubs a cloud-service authorization header with app key, extracts the secret_key_header and returns it as the scrub value" do
+      secret_key = "somesecretkeyvaluel0l"
       secret_key_header = "S9qb802LOup/zg3cd4m+CDsR"
+      key_type = "stord_ak"
 
       conn =
         :post
         |> conn("/hello/world", [])
-        |> put_req_header("authorization", "Bearer stord_ak_#{secret_key_header}_somesecretkeyvaluel0l")
+        |> put_req_header("authorization", "Bearer #{key_type}_#{secret_key_header}_#{secret_key}")
 
       log =
         capture_io(:standard_error, fn ->
@@ -129,10 +135,12 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
           Process.sleep(10)
         end)
 
+      expected_scrubbed_value = "#{key_type}_#{secret_key_header}_*********"
+
       assert %{
                "http" => %{
                  "request_headers" => %{
-                   "authorization" => ^secret_key_header
+                   "authorization" => ^expected_scrubbed_value
                  }
                }
              } = Jason.decode!(log)

--- a/test/unit/logger_json/plug/datadog_logger_test.exs
+++ b/test/unit/logger_json/plug/datadog_logger_test.exs
@@ -90,6 +90,30 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
              } = Jason.decode!(log)
     end
 
+    test "scrubs a cloud-service authorization header, extracts the secret_key_header and returns it as the scrub value" do
+      secret_key_header = "S9qb802LOup/zg3cd4m+CDsR"
+
+      conn =
+        :post
+        |> conn("/hello/world", [])
+        |> put_req_header("authorization", "Bearer stord_sk_#{secret_key_header}_somesecretkeyvaluel0l")
+
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
+
+      assert %{
+               "http" => %{
+                 "request_headers" => %{
+                   "authorization" => ^secret_key_header
+                 }
+               }
+             } = Jason.decode!(log)
+    end
+
     test "logs request body" do
       conn =
         :post
@@ -184,6 +208,10 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
       def reverse(value) do
         String.reverse(value)
       end
+
+      def secret_key_processor(value) do
+        String.slice(value, -4..-1)
+      end
     end
 
     setup do
@@ -258,6 +286,34 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
                  "request_headers" => %{
                    "some-unicorn-key-super-special-lul" => "$$$$",
                    "use-a-callback" => ^expected_callback_result
+                 }
+               }
+             } = Jason.decode!(log)
+    end
+
+    test "allows for overriding the special case impl. of the authorization header" do
+      override_application_env(:logger_json, :scrub_overrides, %{
+        "authorization" => {ScrubHelpers, :secret_key_processor, []}
+      })
+
+      last4 = "el0l"
+
+      conn =
+        :post
+        |> conn("/hello/world", [])
+        |> put_req_header("authorization", "Bearer stord_sk_1234567890_somesecretkeyvalu#{last4}")
+
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
+
+      assert %{
+               "http" => %{
+                 "request_headers" => %{
+                   "authorization" => ^last4
                  }
                }
              } = Jason.decode!(log)


### PR DESCRIPTION
Following up on #11.

This slightly DRYs up the code with `apply_scrubbing` and introduces `extract_public_key/2`. This will automatically do the right thing when services bump their version _without_ specifying any additional config, but also allows for them to override this behavior when necessary.

A pipeline and parsing rule has been setup in DataDog to support this. Looks like:

![image](https://github.com/stordco/logger_json/assets/784953/ffaa4e14-adbb-4f7f-bf49-79cf2f60ac34)

A mirroring PR for the behavior is in the gateway: https://github.com/stordco/public-api-gateway/pull/163/files
