### PR TITLE
fix: scrub x-api-key

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -19,7 +19,8 @@ if Code.ensure_loaded?(Plug) do
       "password",
       "secret",
       "x-cloud-signature",
-      "x-authorization"
+      "x-authorization",
+      "x-api-key"
     ]
     @scrubbed_value "*********"
 

--- a/test/unit/logger_json/plug/datadog_logger_test.exs
+++ b/test/unit/logger_json/plug/datadog_logger_test.exs
@@ -71,6 +71,7 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
         |> put_req_header("authorization", "Bearer TESTING")
         |> put_req_header("cookie", "iwannacookie")
         |> put_req_header("x-cloud-signature", "pleasedontleakmebro")
+        |> put_req_header("x-api-key", "iamabanana")
 
       log =
         capture_io(:standard_error, fn ->
@@ -84,7 +85,8 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
                  "request_headers" => %{
                    "authorization" => "*********",
                    "cookie" => "*********",
-                   "x-cloud-signature" => "*********"
+                   "x-cloud-signature" => "*********",
+                   "x-api-key" => "*********"
                  }
                }
              } = Jason.decode!(log)


### PR DESCRIPTION
Activity service uses `x-api-key`. We'll need to scrub this, rotate keys, etc etc. 