### PR TITLE
fix: don't scrub uploads

### DIFF
--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -144,6 +144,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp recursive_scrub(%{__struct__: Plug.Conn.Unfetched}, _scrub_map), do: "%Plug.Conn.Unfetched{}"
+    defp recursive_scrub(%Plug.Upload{}, _scrub_map), do: "%Plug.Upload{}"
 
     defp recursive_scrub([head | _tail] = data, scrub_map) when is_tuple(head),
       do: data |> Enum.map(&recursive_scrub(&1, scrub_map)) |> Map.new()

--- a/test/unit/logger_json/plug/datadog_logger_test.exs
+++ b/test/unit/logger_json/plug/datadog_logger_test.exs
@@ -195,6 +195,30 @@ defmodule LoggerJSON.Plug.MetadataFormatters.DatadogLoggerTest do
                }
              } = Jason.decode!(log)
     end
+
+    test "doesn't blow up during uploads" do
+      conn =
+        :post
+        |> conn("/upload", %Plug.Upload{
+          content_type: "text/csv",
+          filename: "example.csv",
+          path: "/tmp/plug-1707-lAW6/multipart-1707338489-738149684841-4"
+        })
+        |> put_req_header("content-type", "multipart/form-data")
+
+      log =
+        capture_io(:standard_error, fn ->
+          MyPlug.call(conn, [])
+          Logger.flush()
+          Process.sleep(10)
+        end)
+
+      assert %{
+               "http" => %{
+                 "request_params" => "%Plug.Upload{}"
+               }
+             } = Jason.decode!(log)
+    end
   end
 
   describe "configuration: :scrubbed_value" do


### PR DESCRIPTION
We were trying to scrub a `Plug.Upload` struct, which isn't the right idea. This will just return `%Plug.Upload` as the params in the logs.